### PR TITLE
fix: No named parameter with the name 'onPopInvokedWithResult'

### DIFF
--- a/lib/common/widgets/double_press_back.dart
+++ b/lib/common/widgets/double_press_back.dart
@@ -47,7 +47,7 @@ class DoublePressBackWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return PopScope(
       canPop: false,
-      onPopInvokedWithResult: (bool didPop, value) async {
+      onPopInvoked: (bool didPop) async {
         if (didPop) {
           return;
         }


### PR DESCRIPTION
运行示例项目报错：`../lib/common/widgets/double_press_back.dart:50:7 文件中，错误是 No named parameter with the name 'onPopInvokedWithResult'。`

1. 在 Flutter 3.22.3 版本中，PopScope 组件的 onPopInvokedWithResult 参数已被移除
2. 新版本中该参数被替换为 onPopInvoked